### PR TITLE
Multiple file support

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -108,8 +108,6 @@ static std::string process_script(std::string file_contents, std::string contain
         }
     }
 
-    DEBUG("\n" + res);
-
     return std::string(res);
 }
 

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -109,7 +109,7 @@ static std::string process_script(std::string file_contents, std::string contain
         }
     }
 
-    return std::string(file_contents);
+    return std::string(res);
 }
 
 namespace lmake {

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -80,8 +80,8 @@ static std::string process_script(std::string file_contents, std::string contain
         if(temp.find("lmake_include") != std::string::npos) {
             // Get the parameter passed to lmake_include command
             size_t bracket_left_index = temp.find("(\"") + 2;
-            size_t bracket_right_index = temp.find("\")")  - bracket_left_index;
-            std::string substring = temp.substr(bracket_left_index, bracket_right_index);
+            size_t substring_size = temp.find("\")")  - bracket_left_index;
+            std::string substring = temp.substr(bracket_left_index, substring_size);
 
             // Check if file exists, if not, throw an error and quit
             if(!os::file_exists(substring.c_str())) {

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -82,7 +82,6 @@ static std::string process_script(std::string file_contents, std::string contain
             size_t bracket_left_index = temp.find("(\"") + 2;
             size_t bracket_right_index = temp.find("\")")  - bracket_left_index;
             std::string substring = temp.substr(bracket_left_index, bracket_right_index);
-            DEBUG(substring);
 
             // Check if file exists, if not, throw an error and quit
             if(!os::file_exists(substring.c_str())) {
@@ -92,7 +91,6 @@ static std::string process_script(std::string file_contents, std::string contain
             }
 
             auto file_contents = os::read_file(substring);
-            DEBUG(file_contents.get());
 
             // Get the path to the included file
             std::string directory;

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -95,14 +95,14 @@ static std::string process_script(std::string file_contents, std::string contain
             // Get the path to the included file
             std::string directory;
             const size_t last_slash_idx = substring.rfind('\\');
-            if (std::string::npos != last_slash_idx)
-            {
+            if (std::string::npos != last_slash_idx) {
                 directory = substring.substr(0, last_slash_idx);
             }
-
+            res.append("lmake_chdir(" + directory + ")\n");
             res.append("\n");
             res.append(std::string(file_contents.get()));
             res.append("\n");
+            res.append("lmake_chdir_last()\n");
         } else {
             res.append(temp);
             res.append("\n");

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -79,9 +79,10 @@ static std::string process_script(std::string file_contents, std::string contain
     while(std::getline(stream, temp)) {
         if(temp.find("lmake_include") != std::string::npos) {
             // Get the parameter passed to lmake_include command
-            size_t bracket_left_index = temp.find("(\"");
-            size_t bracket_right_index = temp.find("\")");
+            size_t bracket_left_index = temp.find("(\"") + 2;
+            size_t bracket_right_index = temp.find("\")")  - bracket_left_index;
             std::string substring = temp.substr(bracket_left_index, bracket_right_index);
+            DEBUG(substring);
 
             // Check if file exists, if not, throw an error and quit
             if(!os::file_exists(substring.c_str())) {
@@ -91,6 +92,7 @@ static std::string process_script(std::string file_contents, std::string contain
             }
 
             auto file_contents = os::read_file(substring);
+            DEBUG(file_contents.get());
 
             // Get the path to the included file
             std::string directory;
@@ -98,16 +100,15 @@ static std::string process_script(std::string file_contents, std::string contain
             if (std::string::npos != last_slash_idx) {
                 directory = substring.substr(0, last_slash_idx);
             }
-            res.append("lmake_chdir(" + directory + ")\n");
-            res.append("\n");
+
             res.append(std::string(file_contents.get()));
-            res.append("\n");
-            res.append("lmake_chdir_last()\n");
         } else {
             res.append(temp);
             res.append("\n");
         }
     }
+
+    DEBUG("\n" + res);
 
     return std::string(res);
 }


### PR DESCRIPTION
Implementation for [this](https://github.com/IkerGalardi/LMake/issues/6) issue.

The approach is to make a little preprocessing step before executing the script where the contents of the other files are copied. To follow the issue correctly and the new script be executed on the path its resides, `lmake_chdir` commands are added to solve the relative paths problem.

TODO list:
- [x] File copying
- [ ] Relative paths problem (chdir before and after)
- [x] Nested includes