### PR TITLE
Settings manager and force recompile setting

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -51,6 +51,8 @@ static struct {
     bool config_executed = false;
 
     std::string last_error;
+
+    lmake::settings settings;
 } lmake_data;
 
 #define PRINT_IF(m, b) if(b) std::cout << m << std::endl
@@ -94,7 +96,9 @@ static std::string process_script(std::string file_contents, std::string contain
 }
 
 namespace lmake {
-    void initialize() {
+    void initialize(const settings& settings) {
+        lmake_data.settings = settings;
+
         lmake_data.vm.add_native_function([](lua_State* vm) -> int {
             auto compatibility_version = lua_tonumber(vm, -1);
             if(compatibility_version != LMAKE_COMPAT_VERSION) {
@@ -150,9 +154,12 @@ namespace lmake {
                     file_without_path
                 );
 
-                if(os::file_exists(obj_name)) {
-                    if(!os::compare_file_dates(obj_name, files[0])) {
-                        continue;
+                /// TODO: rewrite this pls
+                if(!lmake_data.settings.force_recompile) {
+                    if(os::file_exists(obj_name)) {
+                        if(!os::compare_file_dates(obj_name, files[0])) {
+                            continue;
+                        }
                     }
                 }
 

--- a/src/lmake.hh
+++ b/src/lmake.hh
@@ -22,10 +22,16 @@
 #define LMAKE_COMPAT_VERSION 1.0
 
 namespace lmake {
+    struct settings {
+        bool force_recompile = false;
+    };
+
     /*
      * Initializes de luavm and adds all the necesary native functions.
+     * 
+     * @param settings: settings that lmake will use
      */
-    void initialize();
+    void initialize(const settings& settings);
 
     /*
      * Loads the file from the filesystem system, preprocesses it (replaces 

--- a/src/main.cc
+++ b/src/main.cc
@@ -58,7 +58,10 @@ int main(int argc, char** argv) {
         std::exit(1);
     }
 
-    lmake::initialize();
+    lmake::settings settings;
+    settings.force_recompile = true;
+
+    lmake::initialize(settings);
 
     if(!lmake::load_from_file(LMAKE_CONFIG_PATH)) {
         std::cerr << "[E] " << lmake::get_last_error() << std::endl;

--- a/src/main.cc
+++ b/src/main.cc
@@ -36,7 +36,6 @@ void print_usage() {
 }
 
 int main(int argc, char** argv) {
-
     if(argc <= 1 || std::strcmp(argv[1], "--help") == 0) {
         print_usage();
         std::exit(0);
@@ -59,10 +58,13 @@ int main(int argc, char** argv) {
     }
 
     lmake::settings settings;
-    settings.force_recompile = true;
+    for(int i = 0; i < argc; i++) {
+        if(std::string(argv[i]) == std::string("--recompile")) {
+            settings.force_recompile = true;
+        }
+    }
 
     lmake::initialize(settings);
-
     if(!lmake::load_from_file(LMAKE_CONFIG_PATH)) {
         std::cerr << "[E] " << lmake::get_last_error() << std::endl;
         std::exit(3);
@@ -71,7 +73,7 @@ int main(int argc, char** argv) {
     if(argc >= 1) {
         lmake::execute_target(argv[1]);
     } else {
-        std::cout << "[I] No target specified\n";
+        std::cout << "[E] No target specified\n";
         std::exit(1);
     }
     


### PR DESCRIPTION
This is the implementation for [this](https://github.com/IkerGalardi/LMake/issues/10) issue.

Implementation of settings manager.
Using flag --recompile the force_recompile setting is enabled and always compiles all files.