### PR TITLE
Find source and object files using regex

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -293,7 +293,7 @@ namespace lmake {
             size_t single_pos = to_match.find("*");
             if(double_pos != std::string::npos) {
                 /// TODO: implement recursive function
-                std::cerr << 
+                std::cerr << "[E] ** regex not supported for now.\n"; 
             } else if(single_pos != std::string::npos) {
                 std::string left_part = to_match.substr(0, single_pos);
                 std::string right_part = to_match.substr(single_pos + 1, to_match.size() - single_pos);

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -293,6 +293,7 @@ namespace lmake {
             size_t single_pos = to_match.find("*");
             if(double_pos != std::string::npos) {
                 /// TODO: implement recursive function
+                std::cerr << 
             } else if(single_pos != std::string::npos) {
                 std::string left_part = to_match.substr(0, single_pos);
                 std::string right_part = to_match.substr(single_pos + 1, to_match.size() - single_pos);
@@ -314,7 +315,6 @@ namespace lmake {
                     "\\."
                 );
 
-                std::string regex_string_test = "^\\./[a-zA-Z0-9_]*\\.lua$";
                 std::regex regex(regex_complete);
                 std::smatch match;
                 std::string path = os::file_dir(to_match);

--- a/src/os/filesystem.cc
+++ b/src/os/filesystem.cc
@@ -65,4 +65,16 @@ namespace os {
         return edited_a < edited_b;
     }
 
+    std::vector<std::string> list_dir(const std::string& dir) {
+        // Create the result vector (and resize to 6 elements, kinda random number)
+        std::vector<std::string> res;
+        res.resize(6);
+        
+        std::filesystem::directory_iterator iterator(dir);
+        for(auto& entry : iterator) {
+            res.push_back(entry.path().string());
+        }
+
+        return res;
+    }
 }

--- a/src/os/filesystem.cc
+++ b/src/os/filesystem.cc
@@ -66,9 +66,7 @@ namespace os {
     }
 
     std::vector<std::string> list_dir(const std::string& dir) {
-        // Create the result vector (and resize to 6 elements, kinda random number)
         std::vector<std::string> res;
-        res.resize(6);
         
         std::filesystem::directory_iterator iterator(dir);
         for(auto& entry : iterator) {
@@ -76,5 +74,17 @@ namespace os {
         }
 
         return res;
+    }
+
+
+    std::string file_dir(const std::string& file) {
+        std::string directory;
+        const size_t last_slash_idx = file.rfind('\\');
+        if (std::string::npos != last_slash_idx)
+        {
+            directory = file.substr(0, last_slash_idx);
+        }
+
+        return directory;
     }
 }

--- a/src/os/filesystem.hh
+++ b/src/os/filesystem.hh
@@ -17,6 +17,7 @@
 #pragma once 
 
 #include <memory>
+#include <vector>
 
 namespace os {
 
@@ -54,4 +55,13 @@ namespace os {
      * @return: true if file_a is older than file_b, false if not
      */
     bool compare_file_dates(const std::string& file_a, const std::string& file_b);
+
+    /*
+     * Returns an array of files and folders of a directory
+     * 
+     * @param dir: directory of folder to search
+     * 
+     * @return: Array of files and folders
+     */
+    std::vector<std::string> list_dir(const std::string& dir);
 }

--- a/src/os/filesystem.hh
+++ b/src/os/filesystem.hh
@@ -64,4 +64,13 @@ namespace os {
      * @return: Array of files and folders
      */
     std::vector<std::string> list_dir(const std::string& dir);
+
+    /*
+     * Returns the path to the specified file
+     * 
+     * @param file: path to the file
+     * 
+     * @return: path to the file 
+     */
+    std::string file_dir(const std::string& file);
 }


### PR DESCRIPTION
It is tedious to have to write manually all the files that need to be compiled and linked. As used in cmake and makefiles, this project needs the functionality to find files automatically.

lmake_find(regex) command is needed. The regex should be the next: `relative/path/*.c` to find just in the relative/path folder or `relative/path/**.c` to search also in subfolders.