### PR TITLE
Not recompiling bug fixed

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -176,7 +176,7 @@ namespace lmake {
                 /// TODO: rewrite this pls
                 if(!lmake_data.settings.force_recompile) {
                     if(os::file_exists(obj_name)) {
-                        if(!os::compare_file_dates(obj_name, files[0])) {
+                        if(!os::compare_file_dates(obj_name, files[i])) {
                             continue;
                         }
                     }


### PR DESCRIPTION
LMake compares dates not to compile unnecessary. Date comparisons where done wrongly so when editing certain files wrong files where recompiled. 

In this patch that bug is fixed. IDK why the comparisons where not done using the object file and the corresponding source file, instead, compared with the first source file. Now that's fixed.