### PR TITLE
Refactor

### DIFF
--- a/lmake.make
+++ b/lmake.make
@@ -59,6 +59,7 @@ OBJECTS :=
 
 GENERATED += $(OBJDIR)/filesystem.o
 GENERATED += $(OBJDIR)/lmake.o
+GENERATED += $(OBJDIR)/lmake_func.o
 GENERATED += $(OBJDIR)/luavm.o
 GENERATED += $(OBJDIR)/main.o
 GENERATED += $(OBJDIR)/process_management.o
@@ -66,6 +67,7 @@ GENERATED += $(OBJDIR)/test.o
 GENERATED += $(OBJDIR)/utils.o
 OBJECTS += $(OBJDIR)/filesystem.o
 OBJECTS += $(OBJDIR)/lmake.o
+OBJECTS += $(OBJDIR)/lmake_func.o
 OBJECTS += $(OBJDIR)/luavm.o
 OBJECTS += $(OBJDIR)/main.o
 OBJECTS += $(OBJDIR)/process_management.o
@@ -135,6 +137,9 @@ endif
 # #############################################
 
 $(OBJDIR)/lmake.o: src/lmake.cc
+	@echo $(notdir $<)
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/lmake_func.o: src/lmake_func.cc
 	@echo $(notdir $<)
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/luavm.o: src/luavm.cc

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -168,8 +168,6 @@ namespace lmake {
                 lua_pushstring(vm, res);
 
                 return 1;
-
-                /// TODO: check with regex
             } else {
                 std::cerr << "[E] There is no regex in: " << to_match << std::endl;
                 std::exit(1);

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -202,7 +202,8 @@ namespace lmake {
 
     bool execute_target(std::string target) {
         if(!vm.function_exists(target)) {
-//            lmake_data.last_error = "Specified target does not exist";
+            std::cerr << "[E] Target " << target << " does not exist\n";
+            std::exit(1);
             return false;
         }
 

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -162,11 +162,11 @@ namespace lmake {
             size_t single_pos = to_match.find("*");
             if(double_pos != std::string::npos) {
                 /// TODO: implement recursive function
-                std::cerr << "[E] ** regex not supported for now.\n"; 
+                std::cerr << "[E] ** regex not supported for now.\n";
+                std::exit(1);
             } else if(single_pos != std::string::npos) {
                 char* res = lmake::func::find(to_match);
                 lua_pushstring(vm, res);
-
                 return 1;
             } else {
                 std::cerr << "[E] There is no regex in: " << to_match << std::endl;
@@ -183,36 +183,25 @@ namespace lmake {
         }, "lmake_error");
     }
 
-    bool load_from_file(std::string config_path) {
+    void load_from_file(std::string config_path) {
         auto file_buffer = os::read_file(config_path);
         std::string processed = process_script(file_buffer.get(), config_path);
-        return lmake::load_from_string(processed.c_str());
+        lmake::load_from_string(processed.c_str());
     }
 
-    bool load_from_string(std::string config_string) {
+    void load_from_string(std::string config_string) {
         if(!vm.execute_script(config_string)) {
-//            lmake_data.last_error = vm.get_last_error();
-            return false;
+            std::cerr << "[E] An error has ocurred when executing script\n";
+            std::exit(1);
         }
-
-//       lmake_data.config_executed = true;
-
-        return true;
     }
 
-    bool execute_target(std::string target) {
+    void execute_target(std::string target) {
         if(!vm.function_exists(target)) {
             std::cerr << "[E] Target " << target << " does not exist\n";
             std::exit(1);
-            return false;
         }
 
         vm.execute_function(target);
-
-        return true;
-    }
-
-    std::string& get_last_error() {
- //       return lmake_data.last_error;
     }
 }

--- a/src/lmake.hh
+++ b/src/lmake.hh
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#define LMAKE_VERSION "0.7 DEV"
+#define LMAKE_VERSION "1.0.0 DEV"
 #define LMAKE_COMPAT_VERSION 1.0
 
 namespace lmake {

--- a/src/lmake.hh
+++ b/src/lmake.hh
@@ -40,7 +40,7 @@ namespace lmake {
      * @param config_path: path to the configuration file
      * @return: true if success, false if something went wrong
      */
-    bool load_from_file(std::string config_path);
+    void load_from_file(std::string config_path);
 
     /*
      * Executes the provided string without any processing.
@@ -48,7 +48,7 @@ namespace lmake {
      * @param config_path: path to the configuration file
      * @return: true if success, false if something went wrong
      */
-    bool load_from_string(std::string config_string);
+    void load_from_string(std::string config_string);
 
     /*
      * Executes the specified target function
@@ -56,12 +56,5 @@ namespace lmake {
      * @param target: name of the target
      * @return: true if success, false if something went wrong
      */
-    bool execute_target(std::string target);
-
-    /*
-     * Returns the last error that occured.
-     * 
-     * @return: string explaining the error
-     */
-    std::string& get_last_error();
+    void execute_target(std::string target);
 }

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -206,7 +206,7 @@ namespace lmake { namespace func {
         std::exit(2);
     }
 
-    char* find(const std::string regex) {
+    char* find(const std::string& regex) {
         const std::string template_regex_complete = "^%[a-zA-Z0-9_]*?$"; // % by left part, ? by right part
 
         size_t single_pos = regex.find("*");

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -1,0 +1,208 @@
+#include "lmake_func.hh"
+
+#include <memory>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <stack>
+
+#include <stringtoolbox/stringtoolbox.hh>
+
+
+#include "luavm.hh"
+#include "os/filesystem.hh"
+#include "os/process_management.hh"
+#include "lmake.hh"
+#include "utils.hh"
+
+#define PRINT_IF(m, b) if(b) std::cout << m << std::endl
+
+#define DEBUG(x) std::cout << "[D] " << x << std::endl
+
+static struct {
+    struct {
+        std::string compiler;
+        std::string compiler_flags;
+        std::string compiler_output;
+
+        std::string linker;
+        std::string linker_flags;
+        std::string linker_output;
+    } context;
+
+    std::stack<std::string> been_dirs;
+
+    bool initialized = false;
+    bool config_executed = false;
+
+    std::string last_error;
+
+    lmake::settings settings;
+} lmake_data;
+
+
+namespace lmake { namespace func {
+
+    void set_settings(const settings& settings) {
+        lmake_data.settings = settings;
+    }
+
+    void compatibility_version(float compatibility_version) {
+        if(compatibility_version != LMAKE_COMPAT_VERSION) {
+            std::cerr << "[E] Incompatible version\n";
+            std::exit(0);
+        }
+    }
+
+    void set_compiler(const std::string& compiler) {
+        lmake_data.context.compiler = compiler;        
+    }
+
+    void set_compiler_flags(const std::string& flags) {
+        lmake_data.context.compiler_flags = flags;
+    }
+
+    void set_compiler_out(const std::string& out_regex) {
+        if(out_regex.find('%') == std::string::npos) {
+            std::cerr << "[E] No regex added.\n";
+            std::exit(1);
+        }
+
+        lmake_data.context.compiler_output = out_regex;
+    }
+
+    void compile(const std::string& source_files) {
+        std::vector<std::string> files = utils::string_split(source_files, ' ');
+        for(int i = 0; i < files.size(); i++) {
+            std::string& compiler = lmake_data.context.compiler;
+            std::string& flags = lmake_data.context.compiler_flags;
+            std::string& out = lmake_data.context.compiler_output;
+
+            std::filesystem::path file_path(files[i]);
+            std::string file_without_path = file_path.stem().string() + file_path.extension().string();
+
+            std::string obj_name = utils::string_replace(
+                out,
+                "%",
+                file_without_path
+            );
+
+            /// TODO: rewrite this pls
+            if(!lmake_data.settings.force_recompile) {
+                if(os::file_exists(obj_name)) {
+                    if(!os::compare_file_dates(obj_name, files[i])) {
+                        continue;
+                    }
+                }
+            }
+
+            std::cout << "[+] Compiling " << files[i] << std::endl;
+            bool ok = utils::compile(
+                compiler.c_str(),
+                flags.c_str(),
+                files[i].c_str(),
+                obj_name.c_str()
+            );
+
+            if(!ok) 
+                std::exit(1);
+        }
+    }
+
+    void set_linker(const std::string& linker) {
+        lmake_data.context.linker = linker;
+    }
+
+    void set_linker_flags(const std::string& flags) {
+        lmake_data.context.linker_flags = flags;
+    }
+
+    void set_linker_out(const std::string& out_regex) {
+        lmake_data.context.linker_output = out_regex;
+    }
+
+    void link(const std::string& object_files) {
+        std::string& linker = lmake_data.context.linker; 
+        std::string& flags = lmake_data.context.linker_flags;
+        std::string& output = lmake_data.context.linker_output;
+
+        std::filesystem::path output_path(output);
+        std::cout << "[+] Linking " << output_path.filename().string() << std::endl;
+
+        // Construct the args
+        std::string args = "-o " + output + " " + object_files + " " + flags;
+
+        // Execute the linker with the constructed args
+        os::process p = os::run_process(linker.c_str(), args.c_str());
+        int exit_code = os::wait_process(p);
+
+        if(exit_code != 0) {
+            std::exit(1);
+        }
+    }
+
+    void chdir(const std::string& dir) {
+        if(os::change_dir(dir.c_str())) {
+            lmake_data.been_dirs.push(os::get_dir());
+        } else {
+            std::cerr << "[E] Specified directory can't be entered.\n";
+            std::exit(1);
+        }
+    }
+
+    void last_dir() {
+        std::stack<std::string>& been_dirs = lmake_data.been_dirs;
+            
+        // Check if it can go back a directory
+        if(been_dirs.empty() || been_dirs.size() == 1) {
+            std::cerr << "[E] Can't go back a directory\n";
+            std::exit(1);
+        }
+
+        // Take the previous directory
+        been_dirs.pop();
+        std::string prev_dir = been_dirs.top();
+            
+        // Change to the previous directory
+        if(!os::change_dir(prev_dir)) {
+            std::cerr << "[E] Specified directory can't be entered.\n";
+            std::exit(1);
+        }
+    }
+
+    int exec(const std::string command) {
+        auto splited_params = utils::string_split(command, ' ');
+
+        if(splited_params.size() == 0) {
+            std::cerr << "[E] Unknown syntax.\n";
+            std::exit(1);
+        }
+
+        /// TODO: maybe look inside PATH instead of manual checks
+        std::string real_prog;
+        if(os::file_exists(splited_params[0])) {
+            real_prog = splited_params[0];
+        } else if(os::file_exists("/bin/" + splited_params[0])) {
+            real_prog = "/bin/" + splited_params[0];
+        } else if(os::file_exists("/usr/bin/" + splited_params[0])) {
+            real_prog = "/usr/bin/" + splited_params[0];
+        } else {
+            std::cerr << "[E] " << splited_params[0] << " was not found\n";
+        }
+
+        std::string params;
+        for(int i = 1; i < splited_params.size(); i++) {
+            params.append(splited_params[i] + " ");
+        }
+
+        os::process p = os::run_process(real_prog, params);
+        int exit = os::wait_process(p);
+        return exit;
+    }
+
+    void error(const std::string msg) {
+        std::cout << "[E] " << msg << std::endl;
+        std::exit(2);
+    }
+
+} }

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -206,7 +206,7 @@ namespace lmake { namespace func {
         std::exit(2);
     }
 
-    std::string find(const std::string regex) {
+    char* find(const std::string regex) {
         const std::string template_regex_complete = "^%[a-zA-Z0-9_]*?$"; // % by left part, ? by right part
 
         size_t single_pos = regex.find("*");

--- a/src/lmake_func.hh
+++ b/src/lmake_func.hh
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "lmake.hh"
+
+namespace lmake { namespace func {
+
+    void set_settings(const settings& settings);
+
+    void compatibility_version(float compatibility_version);
+
+    void set_compiler(const std::string& compiler);
+
+    void set_compiler_flags(const std::string& flags);
+
+    void set_compiler_out(const std::string& out_regex);
+
+    void compile(const std::string& source_files);
+
+    void set_linker(const std::string& linker);
+
+    void set_linker_flags(const std::string& flags);
+
+    void set_linker_out(const std::string& out_regex);
+
+    void link(const std::string& object_files);
+
+    void chdir(const std::string& dir);
+
+    void last_dir();
+
+    int exec(const std::string command);
+
+    void error(const std::string msg);
+
+} }

--- a/src/main.cc
+++ b/src/main.cc
@@ -61,10 +61,7 @@ int main(int argc, char** argv) {
     }
 
     lmake::initialize(settings);
-    if(!lmake::load_from_file(LMAKE_CONFIG_PATH)) {
-        std::cerr << "[E] " << lmake::get_last_error() << std::endl;
-        std::exit(3);
-    }
+    lmake::load_from_file(LMAKE_CONFIG_PATH);
 
     if(argc >= 1) {
         lmake::execute_target(argv[1]);


### PR DESCRIPTION
Refactorization of the code.

All the lmake functions moved into its own files. So now `lmake.cc` just sets up the native functions, parses the arguments and calls the necessary native function. Inside `lmake_func.cc` all the functions are implemented.

Apart from that all non working error checking of inside `main.cc` has moved inside lmake. Now instead of returning the error to main, lmake prints the error message and exits automatically. 