### PR TITLE
Recursive find

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -161,10 +161,14 @@ namespace lmake {
             size_t double_pos = to_match.find("**");
             size_t single_pos = to_match.find("*");
             if(double_pos != std::string::npos) {
-                /// TODO: implement recursive function
-                std::string res = lmake::func::find_recursive(to_match);
-                std::cerr << "[E] ** regex not supported for now.\n";
-                std::exit(1);
+                std::string result = lmake::func::find_recursive(to_match);
+
+                char* res = (char*) std::malloc((result.size() + 1) * sizeof(char));
+                std::strcpy(res, result.c_str());
+                res[result.size()] = '\0';
+
+                lua_pushstring(vm, res);
+                return 1;
             } else if(single_pos != std::string::npos) {
                 char* res = lmake::func::find(to_match);
                 lua_pushstring(vm, res);

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -162,6 +162,7 @@ namespace lmake {
             size_t single_pos = to_match.find("*");
             if(double_pos != std::string::npos) {
                 /// TODO: implement recursive function
+                std::string res = lmake::func::find_recursive(to_match);
                 std::cerr << "[E] ** regex not supported for now.\n";
                 std::exit(1);
             } else if(single_pos != std::string::npos) {

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -270,7 +270,6 @@ namespace lmake { namespace func {
         for(std::string& file : files) {
             if(std::filesystem::is_directory(file)) {
                 std::string new_regex = file + "/**" + right_part;
-                DEBUG(new_regex);
                 result.append(find_recursive(new_regex));
             }
         }
@@ -282,6 +281,6 @@ namespace lmake { namespace func {
             "*"
         );
         result.append(find(new_regex));
-        DEBUG(result);
+        return result;
     }
 } }

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -259,4 +259,29 @@ namespace lmake { namespace func {
         return res;
     }
 
+    std::string find_recursive(const std::string& regex) {
+        size_t double_index = regex.find("**");
+        std::string left_part = regex.substr(0, double_index);
+        std::string right_part = regex.substr(double_index + 2, regex.size() - double_index);
+
+        // Find recursivelly the files
+        std::string result = "";
+        auto files = os::list_dir(left_part);
+        for(std::string& file : files) {
+            if(std::filesystem::is_directory(file)) {
+                std::string new_regex = file + "/**" + right_part;
+                DEBUG(new_regex);
+                result.append(find_recursive(new_regex));
+            }
+        }
+
+        // Find the files in the base directory
+        auto new_regex = utils::string_replace(
+            regex,
+            "**",
+            "*"
+        );
+        result.append(find(new_regex));
+        DEBUG(result);
+    }
 } }

--- a/src/lmake_func.hh
+++ b/src/lmake_func.hh
@@ -33,4 +33,6 @@ namespace lmake { namespace func {
     void error(const std::string msg);
 
     char* find(const std::string& regex);
+
+    std::string find_recursive(const std::string& regex);
 } }


### PR DESCRIPTION
Implemented left feature from issue #7.

Command `lmake_find` can now find files recursively using "**" in the regex as explained on the issue.