### PR TITLE
Enhancement: Print command when lmake_exec

### DIFF
--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -213,6 +213,7 @@ namespace lmake { namespace func {
             params.append(splited_params[i] + " ");
         }
 
+        std::cout << "[+] " << command << std::endl;
         os::process p = os::run_process(real_prog, params);
         int exit = os::wait_process(p);
         return exit;


### PR DESCRIPTION
Implementation of issue #31.

When the command `lmake_exec` executes a process information about it should be printed like when `lmake_compile` is invoked.

Simple print added before executing.