### PR TITLE
Bugfix: crash when unexistent source file tries to be compiled

### DIFF
--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -108,7 +108,8 @@ namespace lmake { namespace func {
             /// TODO: rewrite this pls
             if(!lmake_data.settings.force_recompile) {
                 if(os::file_exists(obj_name)) {
-                    if(!os::compare_file_dates(obj_name, files[i])) {
+                    // Check file dates and if files exists
+                    if(os::file_exists(files[i]) && !os::compare_file_dates(obj_name, files[i])) {
                         continue;
                     }
                 }


### PR DESCRIPTION
When an unexistent file is set to be compiled a crash occurs, this might happen because of the date comparison that is done in order to know if the file needs to be compiled or not.

To fix this, before checking file dates, lmake checks if the file exists. If the file doesnt exist simply tries to compile to give the compiler error and be consistent with other cases. If the file exists, the file date is checked like normal.