### PR TITLE
Bugfix: Commented lmake_include is not ignored

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <stack>
 #include <regex>
+#include <string.h>
 
 #include <stringtoolbox/stringtoolbox.hh>
 
@@ -49,6 +50,9 @@ static std::string process_script(std::string file_contents, std::string contain
 
     std::string temp;
     while(std::getline(stream, temp)) {
+        if(strncmp(temp.c_str(), "--", strlen("--")) == 0) {
+            continue;
+        }
         if(temp.find("lmake_include") != std::string::npos) {
             // Get the parameter passed to lmake_include command
             size_t bracket_left_index = temp.find("(\"") + 2;


### PR DESCRIPTION
Bugfix for issue #29.

When an lmake_include is commented it should be ignored and not tried to be included but it is.

When file was preprocessed, comment lines were not ignored, this meant that the `lmake_include` command still included the file. Now, when the line starts with `--` the line is skipped from pre processing.