### PR TITLE
Enhancement: verbose flag

### DIFF
--- a/src/lmake.hh
+++ b/src/lmake.hh
@@ -24,6 +24,7 @@
 namespace lmake {
     struct settings {
         bool force_recompile = false;
+        bool verbose = false;
     };
 
     /*

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -213,6 +213,7 @@ namespace lmake { namespace func {
             params.append(splited_params[i] + " ");
         }
 
+        std::cout << "[+] " << command << std::endl;
         os::process p = os::run_process(real_prog, params);
         int exit = os::wait_process(p);
         return exit;

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -114,7 +114,11 @@ namespace lmake { namespace func {
                 }
             }
 
-            std::cout << "[+] Compiling " << files[i] << std::endl;
+            if(lmake_data.settings.verbose) {
+                std::cout << "[+]" << compiler + files[i] + " -c " + flags + " -o " + obj_name << std::endl;
+            } else {
+                std::cout << "[+] Compiling " << files[i] << std::endl;
+            }
             bool ok = utils::compile(
                 compiler.c_str(),
                 flags.c_str(),
@@ -145,10 +149,16 @@ namespace lmake { namespace func {
         std::string& output = lmake_data.context.linker_output;
 
         std::filesystem::path output_path(output);
-        std::cout << "[+] Linking " << output_path.filename().string() << std::endl;
 
         // Construct the args
         std::string args = "-o " + output + " " + object_files + " " + flags;
+
+        if(lmake_data.settings.verbose) {
+            std::cout << "[+] " << linker + args << std::endl;
+        } else  {
+            std::cout << "[+] Linking " << output_path.filename().string() << std::endl;
+        }
+
 
         // Execute the linker with the constructed args
         os::process p = os::run_process(linker.c_str(), args.c_str());
@@ -213,7 +223,11 @@ namespace lmake { namespace func {
             params.append(splited_params[i] + " ");
         }
 
-        std::cout << "[+] " << command << std::endl;
+        if(lmake_data.settings.verbose) {
+            std::cout << "[+] " << command << std::endl;
+        } else {
+            std::cout << "[+] Executing " << splited_params[0] << std::endl;
+        }
         os::process p = os::run_process(real_prog, params);
         int exit = os::wait_process(p);
         return exit;

--- a/src/main.cc
+++ b/src/main.cc
@@ -57,6 +57,8 @@ int main(int argc, char** argv) {
     for(int i = 0; i < argc; i++) {
         if(std::string(argv[i]) == std::string("--recompile")) {
             settings.force_recompile = true;
+        } else if(std::string(argv[i]) == std::string("--verbose")) {
+            settings.verbose = true;
         }
     }
 


### PR DESCRIPTION
Implementation of issue #36.

Lmake should have a verbose mode where it prints the exact commands executing instead of a simple message saying `[+] Compiling ...`. This means that `lmake_exec` should only print the command name and print the entire command when verbose is activated. 

This should be implemented as a flag, `--verbose`. As it's done with `--recompile`.

This is implemented by the settings inside `lmake_data.settings`, when this is on, the whole command is printed; when not, a shorter and prettier message is printed. 