### PR TITLE
Bugfix: find memory leak

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -166,7 +166,6 @@ namespace lmake {
             size_t single_pos = to_match.find("*");
             if(double_pos != std::string::npos) {
                 std::string result = lmake::func::find_recursive(to_match);
-
                 char* res = (char*) std::malloc((result.size() + 1) * sizeof(char));
                 std::strcpy(res, result.c_str());
                 res[result.size()] = '\0';
@@ -174,7 +173,10 @@ namespace lmake {
                 lua_pushstring(vm, res);
                 return 1;
             } else if(single_pos != std::string::npos) {
-                char* res = lmake::func::find(to_match);
+                std::string result = lmake::func::find(to_match);
+                char* res = (char*) std::malloc((result.size() + 1) * sizeof(char));
+                std::strcpy(res, result.c_str());
+                res[result.size()] = '\0';
                 lua_pushstring(vm, res);
                 return 1;
             } else {

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -239,7 +239,7 @@ namespace lmake { namespace func {
         std::exit(2);
     }
 
-    char* find(const std::string& regex) {
+    std::string find(const std::string& regex) {
         const std::string template_regex_complete = "^%[a-zA-Z0-9_.]*?$"; // % by left part, ? by right part
 
         size_t single_pos = regex.find("*");
@@ -285,11 +285,7 @@ namespace lmake { namespace func {
             }
         }
 
-        char* res = (char*) std::malloc((result.size() + 1) * sizeof(char));
-        std::strcpy(res, result.c_str());
-        res[result.size()] = '\0';
-
-        return res;
+        return result;
     }
 
     std::string find_recursive(const std::string& regex) {

--- a/src/lmake_func.hh
+++ b/src/lmake_func.hh
@@ -48,7 +48,7 @@ namespace lmake { namespace func {
 
     void error(const std::string msg);
 
-    char* find(const std::string& regex);
+    std::string find(const std::string& regex);
 
     std::string find_recursive(const std::string& regex);
 } }


### PR DESCRIPTION
Inevitable memory leak needs to happen when passing strings to lua, as doing `str.c_str()` when str gets freed by the stack lua will point into garbage memory.

This was a problem because `find` was being called recursively, so now `find` returns a `std::string` and its converted into a malloc-ed `char*` when passed to lua.