### PR TITLE
Bug: lua standard library now available

### DIFF
--- a/src/luavm.cc
+++ b/src/luavm.cc
@@ -20,6 +20,7 @@
 
 luavm::luavm() {
     vm = luaL_newstate();
+    luaL_openlibs(vm);
 
     if(vm == NULL)
         std::cout << "Error while creating the lua virtual machine\n";


### PR DESCRIPTION
Fix for issue #43. The lua standard library could not be used from lmake.

The bug is fixed by calling `lua_openlibs` on luavm initialization.