### PR TITLE
Enhancement: Use path env variable when executing processes.

### DIFF
--- a/src/os/process_management.cc
+++ b/src/os/process_management.cc
@@ -59,7 +59,7 @@ namespace os {
             auto args = string_split_null_terminated(temp, ' ');
 
             int err;
-            if(prog.find("/") == std::string::npos) {
+            if(prog.find("/") != std::string::npos) {
                 err = execv(prog.c_str(), args.data());
             } else {
                 err = execvp(prog.c_str(), args.data());

--- a/src/os/process_management.cc
+++ b/src/os/process_management.cc
@@ -58,7 +58,13 @@ namespace os {
             std::string temp = std::string(prog) + " " + args;
             auto args = string_split_null_terminated(temp, ' ');
 
-            int err = execv(prog.c_str(), args.data());
+            int err;
+            if(prog.find("/") == std::string::npos) {
+                err = execv(prog.c_str(), args.data());
+            } else {
+                err = execvp(prog.c_str(), args.data());
+            }
+
             std::cerr << "[E] Cannot execute process\n";
             std::exit(5);
         }


### PR DESCRIPTION
Implementation for issue #47.

For creating more general lmake scripts that could potentially be more cross platform and more readable, when setting the compiler, linker or executing a system process, instead of giving the full path, the user should be able to just add the program name and lmake search on the `PATH` variable.

On function `run_process` there is a check if a path is there. If there the specified process is inside a path just the process is executed, if not, the executable is searched on `PATH`. This functionality is similar to what bash does on the command line.