### PR TITLE
Bug: linking error no such file or directory when files exist

### DIFF
--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -155,7 +155,7 @@ namespace lmake { namespace func {
         std::filesystem::path output_path(output);
 
         // Construct the args
-        std::string args = "-o " + output + " " + object_files + " " + flags;
+        std::string args = flags + " " + object_files + " " + "-o " + output;
 
         if(lmake_data.settings.verbose) {
             std::cout << "[+] " << linker + " " + args << std::endl;

--- a/src/os/process_management.cc
+++ b/src/os/process_management.cc
@@ -34,6 +34,7 @@ static std::vector<char*> string_split_null_terminated(const std::string& str, c
     std::istringstream stream(str.c_str());
 
     while(std::getline(stream, temp, delimeter)) {
+        if(temp.empty()) continue;
         //res.push_back(std::malloc((temp.size() + 1) * sizeof(char)));
         void* mem = std::calloc(temp.size() + 1, sizeof(char));
         res.push_back(static_cast<char*>(mem));

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -21,8 +21,8 @@ namespace utils {
     }
     
     bool link(const std::string& linker, const std::string& flags, const std::string& obj, const std::string& out) {
-        std::string args = "-o " + out + " " + obj + " " + flags;
-        os::process p = os::run_process(linker.c_str(), args.c_str());
+        std::string args = flags + " " + obj + " " + "-o " + out;
+        os::process p = os::run_process(linker, args);
         int exit_code = os::wait_process(p);
         return exit_code == 0;
     }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -4,6 +4,8 @@
 #include <string>
 #include <sstream>
 
+#include <stringtoolbox/stringtoolbox.hh>
+
 #include "os/process_management.hh"
 
 #define DEBUG(x) std::cout << "[D] " << x << std::endl;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -4,8 +4,6 @@
 #include <string>
 #include <sstream>
 
-#include <stringtoolbox/stringtoolbox.hh>
-
 #include "os/process_management.hh"
 
 #define DEBUG(x) std::cout << "[D] " << x << std::endl;


### PR DESCRIPTION
Fix for issue #38.

Bug turned out to be a problem with empty command line arguments sent to the linker (could also be the compiler). Thats now fixed by the os library by not adding the empty command line argument.