### PR TITLE
Bug: Crash when using regex

### DIFF
--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -250,7 +250,7 @@ namespace lmake { namespace func {
         
         std::string left_part = regex.substr(0, single_pos);
         std::string right_part = regex.substr(single_pos + 1, regex.size() - single_pos);
-                
+
         auto regex_complete = utils::string_replace(
             template_regex_complete,
             "%",
@@ -283,6 +283,11 @@ namespace lmake { namespace func {
 
         std::string result;
         auto files = os::list_dir(path);
+        if(files.empty()) {
+            std::cerr << "[E] Path of regex does not exist.\n";
+            std::exit(1);
+        }
+
         for(std::string file : files) {
             if (std::regex_search(file, match, regex_obj)) {
                 result.append(file + " ");

--- a/src/os/filesystem.cc
+++ b/src/os/filesystem.cc
@@ -66,14 +66,20 @@ namespace os {
     }
 
     std::vector<std::string> list_dir(const std::string& dir) {
-        std::vector<std::string> res;
-        
-        std::filesystem::directory_iterator iterator(dir);
-        for(auto& entry : iterator) {
-            res.push_back(entry.path().string());
-        }
+        try {
+            std::vector<std::string> res;
 
-        return res;
+            std::filesystem::directory_iterator iterator(dir);
+            for(auto& entry : iterator) {
+                res.push_back(entry.path().string());
+            }
+
+            return res;
+        } catch(const std::exception& e) {
+            return std::vector<std::string>();
+        }
+        
+
     }
 
 


### PR DESCRIPTION
Fix for issue #48.

When regex is used on a folder that does not exist a crash occurs.

To fix a try catch statement is used to catch the filesystem exception. When an exception is catched an empty vector is returned, so the user needs to check if the vector is empty or not.