### PR TITLE
Revert "Enhancement: Use path env variable when executing processes"

### DIFF
--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -210,6 +210,18 @@ namespace lmake { namespace func {
             std::exit(1);
         }
 
+        /// TODO: maybe look inside PATH instead of manual checks
+        std::string real_prog;
+        if(os::file_exists(splited_params[0])) {
+            real_prog = splited_params[0];
+        } else if(os::file_exists("/bin/" + splited_params[0])) {
+            real_prog = "/bin/" + splited_params[0];
+        } else if(os::file_exists("/usr/bin/" + splited_params[0])) {
+            real_prog = "/usr/bin/" + splited_params[0];
+        } else {
+            std::cerr << "[E] " << splited_params[0] << " was not found\n";
+        }
+
         std::string params;
         for(int i = 1; i < splited_params.size(); i++) {
             params.append(splited_params[i] + " ");
@@ -220,7 +232,7 @@ namespace lmake { namespace func {
         } else {
             std::cout << "[+] Executing " << splited_params[0] << std::endl;
         }
-        os::process p = os::run_process(splited_params[0], params);
+        os::process p = os::run_process(real_prog, params);
         int exit = os::wait_process(p);
         return exit;
     }


### PR DESCRIPTION
The fix does not work when no path is found.