### PR TITLE
Bug: Test using compiled binary

### DIFF
--- a/test/full_project/test.sh
+++ b/test/full_project/test.sh
@@ -1,10 +1,10 @@
 mkdir -p build
 
 echo "-- Compiling the project"
-lmake build --verbose
+$1 build --verbose
 
 echo "-- Cleaning up obj files"
-lmake clean
+$1 clean
 
 echo "-- Executing test program"
-lmake exec
+$1 exec

--- a/test/internal/test.sh
+++ b/test/internal/test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-lmake --internal-test
+$1 --internal-test

--- a/test/test.sh
+++ b/test/test.sh
@@ -2,13 +2,15 @@
 
 cd test
 
+lmake_executable="../build/lmake"
+
 echo "[+] Running internal test"
-cd internal
-sh test.sh
+cd internal 
+sh test.sh ../$lmake_executable
 cd ..
 
 echo 
 echo "[+] Running full project test"
 cd full_project
-sh test.sh
+sh test.sh ../$lmake_executable
 cd ..


### PR DESCRIPTION
Fix for issue #58 

Tests use installed lmake version instead of locally compiled binary. The tested lmake should be the compiled one and there should not be a need to install a new version.

To fix it, instead of calling directly lmake an argument is passed to the binary by the main `test.sh` file.