### PR TITLE
Feature: change variable values from command line

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -215,4 +215,8 @@ namespace lmake {
 
         vm.execute_function(target);
     }
+    
+    void change_variable(const std::string& name, std::string& value) {
+        vm.change_variable(name, value);
+    }
 }

--- a/src/lmake.hh
+++ b/src/lmake.hh
@@ -60,5 +60,11 @@ namespace lmake {
      */
     void execute_target(std::string target);
 
+    /*
+     * Changes variable 'name' value to 'value' on luavm.
+     * 
+     * @param name: name of the lua variable
+     * @param value: new value of variable
+     */
     void change_variable(const std::string& name, std::string& value);
 }

--- a/src/lmake.hh
+++ b/src/lmake.hh
@@ -59,4 +59,6 @@ namespace lmake {
      * @return: true if success, false if something went wrong
      */
     void execute_target(std::string target);
+
+    void change_variable(const std::string& name, std::string& value);
 }

--- a/src/luavm.cc
+++ b/src/luavm.cc
@@ -17,6 +17,7 @@
 #include "luavm.hh"
 
 #include <iostream>
+#include <cstring>
 
 luavm::luavm() {
     vm = luaL_newstate();
@@ -60,6 +61,14 @@ void luavm::execute_function(std::string fn_name) {
     lua_pcall(vm, 0, 0, 0);
 }
 
+void luavm::change_variable(const std::string& name, const std::string& value) {
+    char* str = static_cast<char*>(std::calloc(value.size() + 1, sizeof(char)));
+    std::strcpy(str, value.c_str());
+    lua_getglobal(vm, name.c_str());
+    lua_remove(vm, 1);
+    lua_pushstring(vm, str);
+    lua_setglobal(vm, name.c_str());
+}
 
 std::string luavm::get_last_error() {
     return std::string("[LVM] ") + last_error;

--- a/src/luavm.hh
+++ b/src/luavm.hh
@@ -69,6 +69,13 @@ public:
      */
     void execute_function(std::string fn_name);
 
+    /*
+     * Searches variable 'name' and changes the value on the 
+     * lua stack to 'value'.
+     * 
+     * @param name: name of the lua variable
+     * @param value: new value of variable
+     */
     void change_variable(const std::string& name, const std::string& value);
 
     /// TODO: errors as enums instead of strings

--- a/src/luavm.hh
+++ b/src/luavm.hh
@@ -69,6 +69,8 @@ public:
      */
     void execute_function(std::string fn_name);
 
+    void change_variable(const std::string& name, const std::string& value);
+
     /// TODO: errors as enums instead of strings
     /* 
      * Returns the last error given by the virtual machine

--- a/src/main.cc
+++ b/src/main.cc
@@ -25,6 +25,8 @@
 
 #define LMAKE_CONFIG_PATH "./lmake.lua"
 
+#define DEBUG(x) std::cout << "[D] " << x << std::endl;
+
 int main(int argc, char** argv) {
     if(argc <= 1 || std::strcmp(argv[1], "--help") == 0) {
         std::cout << "[+] Usage: lmake <target> <flags>\n";
@@ -61,11 +63,23 @@ int main(int argc, char** argv) {
         } else if(std::string(argv[i]) == std::string("--debug")) {
             settings.verbose = true;
             settings.debug = true;
-        }
+        } 
     }
 
     lmake::initialize(settings);
     lmake::load_from_file(LMAKE_CONFIG_PATH);
+
+    for (int i = 0; i < argc; i++) {
+        std::string argvi = std::string(argv[i]);
+        size_t equals_index = argvi.find("=");
+        if(equals_index != std::string::npos) {
+            std::string left_part = argvi.substr(0, equals_index);
+            std::string right_part = argvi.substr(equals_index + 1, argvi.size() - equals_index);
+
+            lmake::change_variable(left_part, right_part);
+        }
+    }
+    
 
     if(argc >= 1) {
         lmake::execute_target(argv[1]);

--- a/test/chvar/lmake.lua
+++ b/test/chvar/lmake.lua
@@ -1,0 +1,6 @@
+VAR = "variable name original"
+
+
+function test()
+    lmake_error(VAR)
+end

--- a/test/chvar/test.sh
+++ b/test/chvar/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$1 test VAR=changed

--- a/test/test.sh
+++ b/test/test.sh
@@ -14,3 +14,9 @@ echo "[+] Running full project test"
 cd full_project
 sh test.sh ../$lmake_executable
 cd ..
+
+echo 
+echo "[+] Running variable changing test"
+cd chvar
+sh test.sh ../$lmake_executable
+cd ..


### PR DESCRIPTION
Fix for issue #32.

It would be a very nice feature to be able to modify script variables on the command line, so that there is no need to change variables for example to change the build type from debug to release for example.

A new function called `change_variable` changes variable's value. From the command line whenever an '=' is found, this function is called.