### PR TITLE
Refactor: no mallocs/news

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -166,18 +166,11 @@ namespace lmake {
             size_t single_pos = to_match.find("*");
             if(double_pos != std::string::npos) {
                 std::string result = lmake::func::find_recursive(to_match);
-                char* res = (char*) std::malloc((result.size() + 1) * sizeof(char));
-                std::strcpy(res, result.c_str());
-                res[result.size()] = '\0';
-
-                lua_pushstring(vm, res);
+                lua_pushstring(vm, result.c_str());
                 return 1;
             } else if(single_pos != std::string::npos) {
                 std::string result = lmake::func::find(to_match);
-                char* res = (char*) std::malloc((result.size() + 1) * sizeof(char));
-                std::strcpy(res, result.c_str());
-                res[result.size()] = '\0';
-                lua_pushstring(vm, res);
+                lua_pushstring(vm, result.c_str());
                 return 1;
             } else {
                 ERROR("There is no regex in: %s", to_match);

--- a/src/luavm.cc
+++ b/src/luavm.cc
@@ -62,11 +62,9 @@ void luavm::execute_function(std::string fn_name) {
 }
 
 void luavm::change_variable(const std::string& name, const std::string& value) {
-    char* str = static_cast<char*>(std::calloc(value.size() + 1, sizeof(char)));
-    std::strcpy(str, value.c_str());
     lua_getglobal(vm, name.c_str());
     lua_remove(vm, 1);
-    lua_pushstring(vm, str);
+    lua_pushstring(vm, value.c_str());
     lua_setglobal(vm, name.c_str());
 }
 


### PR DESCRIPTION
Implementation for issue #63 

It turns out that luavm copies the data passed to it, so lmake should not be scared of deleting that memory. Before, the mallocs where created to persist that memory that lua will use, so they can be safely removed.