### PR TITLE
Refactor: use streams instead of string.append on script processing

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -46,7 +46,6 @@ luavm vm;
 static std::string process_script(const std::string& file_contents, const std::string& containing_dir) {
     std::stringstream stream(file_contents);
     std::stringstream result_stream("");
-    std::string res;
 
     std::string temp;
     while(std::getline(stream, temp)) {

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -45,6 +45,7 @@ luavm vm;
 
 static std::string process_script(const std::string& file_contents, const std::string& containing_dir) {
     std::stringstream stream(file_contents);
+    std::stringstream result_stream("");
     std::string res;
 
     std::string temp;
@@ -75,14 +76,13 @@ static std::string process_script(const std::string& file_contents, const std::s
             }
 
             // Adds the content of the included file
-            res.append(std::string(included_file_contents.get()));
+            result_stream << std::string(included_file_contents.get()) << std::endl;
         } else {
             // Appends the readed line
-            res.append(temp);
-            res.append("\n");
+            result_stream << temp << std::endl;
         }
     }
-    return std::string(res);
+    return result_stream.str();
 }
 
 namespace lmake {


### PR DESCRIPTION
When processing the script, instead of appending into the string a stringstream is used. Theoretically faster appending is faster.