### PR TITLE
Bug: wrong label on debugging messages.

### DIFF
--- a/src/debug.hh
+++ b/src/debug.hh
@@ -2,6 +2,6 @@
 
 #include <stdio.h>
 
-#define DEBUG(...) printf("[E] "); printf(__VA_ARGS__); printf("\n")
+#define DEBUG(...) printf("[D] "); printf(__VA_ARGS__); printf("\n")
 
 #define ERROR(...) fprintf(stderr, "[E] "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n")


### PR DESCRIPTION
Fix for issue #73. Correct label is shown for debug messages now.