### PR TITLE
Bug: malloc error

### DIFF
--- a/src/os/filesystem.cc
+++ b/src/os/filesystem.cc
@@ -42,7 +42,7 @@ namespace os {
         std::fread(buffer.get(), length, 1, file_path);
         std::fclose(file_path);
 
-        buffer.get()[length + 1] = '\0';
+        buffer.get()[length] = '\0';
 
         return buffer;
     }


### PR DESCRIPTION
Fix for issue #69.

Error was caused because of out of bounds on `std::shared_ptr` that is returned with function `os::read_file`. `length + 1` was being read when the buffer was of size `length`.

Some buffers probably work depending on the alignment that the standard library used.

This was tested on old branch where lmake was trying to be built with lmake.  