### PR TITLE
Bug: compilation times

### DIFF
--- a/lmake.make
+++ b/lmake.make
@@ -21,12 +21,12 @@ endif
 RESCOMP = windres
 TARGETDIR = build
 TARGET = $(TARGETDIR)/lmake
-DEFINES +=
+DEFINES += -DSPDLOG_COMPILED_LIB
 INCLUDES += -Ilib/include -Isrc
 FORCE_INCLUDE +=
 ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP $(DEFINES) $(INCLUDES)
 ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
-LIBS += -llua53 -ldl -lspdlog
+LIBS += -llua53 -ldl -lspdlog -lpthread
 LDDEPS +=
 LINKCMD = $(CXX) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)
 define PREBUILDCMDS

--- a/premake5.lua
+++ b/premake5.lua
@@ -16,7 +16,9 @@ project "lmake"
     includedirs {"lib/include", "src"}
 
     libdirs {"lib/bin"}
-    links {"lua53", "dl", "spdlog"}
+    links {"lua53", "dl", "spdlog", "pthread"}
+
+    defines { "SPDLOG_COMPILED_LIB" }
 
     filter "configurations:Debug"
         symbols "on"

--- a/src/main.cc
+++ b/src/main.cc
@@ -19,6 +19,7 @@
 
 #include <lua/lua.hpp>
 #include <spdlog/spdlog.h>
+#include <spdlog/common.h>
 
 #include "os/filesystem.hh"
 #include "lmake.hh"
@@ -28,6 +29,10 @@
 
 int main(int argc, char** argv) {
     spdlog::set_pattern("%^[%l] %v%$");
+
+    #ifdef SPDLOG_HEADER_ONLY
+        spdlog::warn("spdlog is being used as a header only library");
+    #endif
 
     // Checks if "--help" flag is passed, if it is information is printed
     if(argc <= 1 || std::strcmp(argv[1], "--help") == 0) {


### PR DESCRIPTION
Fix for issue #87 

The compilation times before this patch where 45 seconds on my laptop. After this patch, compilation times went down to 10 seconds on the same machine.

The problem was that `spdlog` was used as a header only library instead of using the static library compiled. By defining `SPDLOG_COMPILED_LIB` the header removes all the implementation.