### PR TITLE
Bug: compatibility function incorrect check

### DIFF
--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -62,7 +62,13 @@ namespace lmake {
         }, "lmake_include");
         
         vm.add_native_function([](lua_State* vm) -> int {
-            auto version = lua_tonumber(vm, -1);
+            std::string version;
+            try {
+                version = lua_tostring(vm, -1);
+            } catch(const std::exception& e) {
+                spdlog::error("Incorrect parameters passed to lmake_compatibility_version");
+                std::exit(-1);
+            }
             lmake::func::compatibility_version(version);
             return 1;
         }, "lmake_compatibility_version");

--- a/src/lmake.hh
+++ b/src/lmake.hh
@@ -21,6 +21,7 @@
 constexpr int LMAKE_VERSION_MAJOR = 1;
 constexpr int LMAKE_VERSION_MINOR = 0;
 constexpr int LMAKE_VERSION_PATCH = 0;
+const std::string LMAKE_VERSION_TYPE("BETA");
 
 namespace lmake {
     struct settings {

--- a/src/lmake.hh
+++ b/src/lmake.hh
@@ -18,8 +18,9 @@
 
 #include <string>
 
-#define LMAKE_VERSION "1.0.0 BETA"
-#define LMAKE_COMPAT_VERSION 1.0
+constexpr int LMAKE_VERSION_MAJOR = 1;
+constexpr int LMAKE_VERSION_MINOR = 0;
+constexpr int LMAKE_VERSION_PATCH = 0;
 
 namespace lmake {
     struct settings {

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -58,10 +58,23 @@ namespace lmake { namespace func {
         lmake_data.settings = settings;
     }
 
-    void compatibility_version(float compatibility_version) {
-        if(compatibility_version != LMAKE_COMPAT_VERSION) {
-            spdlog::error("Incompatible version");
-            std::exit(0);
+    void compatibility_version(const std::string& version) {
+        auto versions = stringtoolbox::split(version, '.');
+        if(versions.size() != 3) {
+            spdlog::error("Incorrect formatting of version");
+            std::exit(-1);
+        }
+        try {
+            if(std::stoi(versions[0]) != LMAKE_VERSION_MAJOR) {
+                spdlog::error("Major versions differ, incompatible file");
+                std::exit(-1);
+            } else if(std::stoi(versions[1]) < LMAKE_VERSION_MINOR) {
+                spdlog::error("Minor version is smaller, some functions might not be implemented");
+                std::exit(-1);
+            }
+        } catch(const std::exception& e) {
+            spdlog::error("Incorrect formatting of version");
+            std::exit(-1);
         }
     }
 

--- a/src/lmake_func.hh
+++ b/src/lmake_func.hh
@@ -35,7 +35,7 @@ namespace lmake { namespace func {
      * 
      * @param compatibility_version: version major.minor format
      */
-    void compatibility_version(float compatibility_version);
+    void compatibility_version(const std::string& compatibility_version);
 
     /*
      * Sets the compiler specified on the context

--- a/src/main.cc
+++ b/src/main.cc
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
         std::exit(0);
     } else if(std::strcmp(argv[1], "--version") == 0 || std::strcmp(argv[1], "-v") == 0) {
         std::cout << "[+] Lua version   " << LUA_VERSION_MAJOR "." LUA_VERSION_MINOR << std::endl;
-        std::cout << "[+] LMake version " LMAKE_VERSION "\n";
+        std::cout << "[+] LMake version " << LMAKE_VERSION_MAJOR << "." << LMAKE_VERSION_MINOR << "." << LMAKE_VERSION_PATCH << "\n";
         std::exit(0);
     }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -57,7 +57,10 @@ int main(int argc, char** argv) {
         std::exit(0);
     } else if(std::strcmp(argv[1], "--version") == 0 || std::strcmp(argv[1], "-v") == 0) {
         std::cout << "[+] Lua version   " << LUA_VERSION_MAJOR "." LUA_VERSION_MINOR << std::endl;
-        std::cout << "[+] LMake version " << LMAKE_VERSION_MAJOR << "." << LMAKE_VERSION_MINOR << "." << LMAKE_VERSION_PATCH << "\n";
+        std::cout << "[+] LMake version " << LMAKE_VERSION_MAJOR << "." 
+                                          << LMAKE_VERSION_MINOR << "." 
+                                          << LMAKE_VERSION_PATCH << " " 
+                                          << LMAKE_VERSION_TYPE << "\n";
         std::exit(0);
     }
 

--- a/test/full_project/lmake.lua
+++ b/test/full_project/lmake.lua
@@ -1,4 +1,4 @@
-lmake_compatibility_version(1)
+lmake_compatibility_version("1.0.0")
 
 function build()
     -- Compile the source files


### PR DESCRIPTION
Fix for issue #94 

Now minor and major versions now are checked. If major versions differ an error is shown and if the minor version is smaller an error is showing. 