### PR TITLE
Enhancement: added little space on compilation printing

### DIFF
--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -118,7 +118,7 @@ namespace lmake { namespace func {
             }
 
             if(lmake_data.settings.verbose) {
-                std::cout << "[+]" << compiler + " " + files[i] + " -c " + flags + " -o " + obj_name << std::endl;
+                std::cout << "[+] " << compiler + " " + files[i] + " -c " + flags + " -o " + obj_name << std::endl;
             } else {
                 std::cout << "[+] Compiling " << files[i] << std::endl;
             }


### PR DESCRIPTION
Not related to any issue.

A space character added when printing the compilation command.