### PR TITLE
Refactor: cleaning up `os` layer functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # LMake
+This branch is where all the stable versions reside, if you want to check development versions go to check the 'dev' branch.
+
 LuaMake or LMake is a statement based low level build system aimed to provide flexibility to modify all parts of how your binary is built. LMake is not a project generator, instead, invokes the compiler/linker when necesary.
 
 LMake takes low level seriously, this means that you are able to modify the build commands down to the flags passed to the compiler or linker. This gives you the flexibility needed to, for example, create the build system to compile and link an entire operating system. The only thing LMake takes care off is not to recompile files that haven't been edited.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # LMake
-First of all, this project is currently on **heavy development**. If you are using this software, all bug reports and suggestions are welcome!
-
 LuaMake or LMake is a statement based low level build system aimed to provide flexibility to modify all parts of how your binary is built. LMake is not a project generator, instead, invokes the compiler/linker when necesary.
 
 LMake takes low level seriously, this means that you are able to modify the build commands down to the flags passed to the compiler or linker. This gives you the flexibility needed to, for example, create the build system to compile and link an entire operating system. The only thing LMake takes care off is not to recompile files that haven't been edited.

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -52,7 +52,7 @@ namespace lmake {
             }
 
             // Check if file exits, if not erro and exit
-            if(!os::file_exists(to_include_path)) {
+            if(!std::filesystem::exists(to_include_path)) {
                 spdlog::error("The files {} can't be opened.", to_include_path);
                 std::exit(1);
             }

--- a/src/lmake.cc
+++ b/src/lmake.cc
@@ -40,7 +40,7 @@ namespace lmake {
     void initialize(const settings& settings) {
         lmake::func::set_settings(settings);
 
-        lmake::func::chdir(os::get_dir());
+        lmake::func::chdir(std::filesystem::current_path().string());
 
         vm.add_native_function([](lua_State* vm) -> int {
             const char* to_include_path;

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -122,9 +122,9 @@ namespace lmake { namespace func {
 
             /// TODO: rewrite this pls
             if(!lmake_data.settings.force_recompile) {
-                if(os::file_exists(obj_name)) {
+                if(std::filesystem::exists(obj_name)) {
                     // Check file dates and if files exists
-                    if(os::file_exists(files[i]) && !os::compare_file_dates(obj_name, files[i])) {
+                    if(std::filesystem::exists(files[i]) && !os::compare_file_dates(obj_name, files[i])) {
                         continue;
                     }
                 }
@@ -241,11 +241,11 @@ namespace lmake { namespace func {
 
         /// TODO: maybe look inside PATH instead of manual checks
         std::string real_prog;
-        if(os::file_exists(splited_params[0])) {
+        if(std::filesystem::exists(splited_params[0])) {
             real_prog = splited_params[0];
-        } else if(os::file_exists("/bin/" + splited_params[0])) {
+        } else if(std::filesystem::exists("/bin/" + splited_params[0])) {
             real_prog = "/bin/" + splited_params[0];
-        } else if(os::file_exists("/usr/bin/" + splited_params[0])) {
+        } else if(std::filesystem::exists("/usr/bin/" + splited_params[0])) {
             real_prog = "/usr/bin/" + splited_params[0];
         } else {
             spdlog::error("%s was not found.", splited_params[0].c_str());

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -197,7 +197,8 @@ namespace lmake { namespace func {
             spdlog::info("Changing directory to: {}", dir);
         
         if(os::change_dir(dir.c_str())) {
-            lmake_data.been_dirs.push(os::get_dir());
+            const auto& current_path = std::filesystem::current_path();
+            lmake_data.been_dirs.push(current_path.string());
         } else {
             spdlog::error("Specified directory can't be entered.");
             std::exit(1);

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -122,9 +122,12 @@ namespace lmake { namespace func {
 
             /// TODO: rewrite this pls
             if(!lmake_data.settings.force_recompile) {
+                // If the source file is newer than the object file, or the file object file does not
+                // exist, the source file should be compiled.
                 if(std::filesystem::exists(obj_name)) {
-                    // Check file dates and if files exists
-                    if(std::filesystem::exists(files[i]) && !os::compare_file_dates(obj_name, files[i])) {
+                    const auto& obj_file_last_write = std::filesystem::last_write_time(obj_name);
+                    const auto& src_file_last_write = std::filesystem::last_write_time(files[i]);
+                    if(std::filesystem::exists(files[i]) && (obj_file_last_write > src_file_last_write)) {
                         continue;
                     }
                 }

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -309,17 +309,19 @@ namespace lmake { namespace func {
         // Checks if there are any files on the corresponding directory, if not
         // returns with an error
         std::string result;
-        auto files = os::list_dir(path);
-        if(files.empty()) {
-            spdlog::error("Path of regex does not exist.");
-            std::exit(1);
-        }
-
-        // Loops through the files and tests the regex
-        for(std::string file : files) {
-            if (std::regex_search(file, match, regex_obj)) {
-                result.append(file + " ");
+        try {
+            // Loops through the files and tests the regex
+            std::filesystem::directory_iterator files(path);
+            for (auto& file : files) {
+                const auto& file_string = file.path().string();
+                if (std::regex_search(file_string, match, regex_obj)) {
+                    result.append(file_string + " ");
+                }
             }
+        }
+        catch (const std::exception &e) {
+            spdlog::error("Path of regex does not exist");
+            std::exit(1);
         }
 
         return result;
@@ -335,10 +337,10 @@ namespace lmake { namespace func {
 
         // Find recursivelly the files
         std::string result = "";
-        auto files = os::list_dir(left_part);
-        for(std::string& file : files) {
-            if(std::filesystem::is_directory(file)) {
-                std::string new_regex = file + "/**" + right_part;
+        std::filesystem::directory_iterator files(left_part);
+        for(auto& file : files) {
+            if(file.is_directory()) {
+                std::string new_regex = file.path().string() + "/**" + right_part;
                 result.append(find_recursive(new_regex));
             }
         }

--- a/src/lmake_func.cc
+++ b/src/lmake_func.cc
@@ -196,10 +196,11 @@ namespace lmake { namespace func {
         if(lmake_data.settings.debug)
             spdlog::info("Changing directory to: {}", dir);
         
-        if(os::change_dir(dir.c_str())) {
-            const auto& current_path = std::filesystem::current_path();
+        try {
+            std::filesystem::current_path(dir);
+            const auto &current_path = std::filesystem::current_path();
             lmake_data.been_dirs.push(current_path.string());
-        } else {
+        } catch(const std::exception& e) {
             spdlog::error("Specified directory can't be entered.");
             std::exit(1);
         }
@@ -222,7 +223,9 @@ namespace lmake { namespace func {
         std::string prev_dir = been_dirs.top();
             
         // Change to the previous directory
-        if(!os::change_dir(prev_dir)) {
+        try {
+            std::filesystem::current_path(prev_dir);
+        } catch (const std::exception& e) {
             spdlog::error("Specified directory can't be entered.");
             std::exit(1);
         }

--- a/src/main.cc
+++ b/src/main.cc
@@ -16,6 +16,7 @@
 
 #include <iostream>
 #include <cstring>
+#include <filesystem>
 
 #include <lua/lua.hpp>
 #include <spdlog/spdlog.h>
@@ -84,7 +85,7 @@ int main(int argc, char** argv) {
     }
 
     // Checks if configuration file exists
-    if(!os::file_exists(LMAKE_CONFIG_PATH)) {
+    if(!std::filesystem::exists(LMAKE_CONFIG_PATH)) {
         spdlog::error("No lmake.lua file found.");
         std::exit(1);
     }

--- a/src/os/filesystem.cc
+++ b/src/os/filesystem.cc
@@ -51,13 +51,6 @@ namespace os {
          return chdir(dir.c_str()) == 0;
     }
 
-    std::string get_dir() {
-        char* tmp = getcwd(NULL, 0);
-        std::string res(tmp);
-        std::free(tmp);
-        return res;
-    }
-
     bool compare_file_dates(const std::string& file_a, const std::string& file_b) {
         auto edited_a = std::filesystem::last_write_time(file_a);
         auto edited_b = std::filesystem::last_write_time(file_b);

--- a/src/os/filesystem.cc
+++ b/src/os/filesystem.cc
@@ -47,10 +47,6 @@ namespace os {
         return buffer;
     }
 
-    bool change_dir(const std::string& dir) {
-         return chdir(dir.c_str()) == 0;
-    }
-
     bool compare_file_dates(const std::string& file_a, const std::string& file_b) {
         auto edited_a = std::filesystem::last_write_time(file_a);
         auto edited_b = std::filesystem::last_write_time(file_b);

--- a/src/os/filesystem.cc
+++ b/src/os/filesystem.cc
@@ -22,15 +22,6 @@
 #include <filesystem>
 
 namespace os {
-    bool file_exists(const std::string& path) {
-        FILE *file;
-        if ((file = fopen(path.c_str(), "r"))) {
-            fclose(file);
-            return true;
-        }
-        return false;
-    }
-
     std::shared_ptr<char> read_file(const std::string& path) {
         FILE* file_path = std::fopen(path.c_str(), "r");
 

--- a/src/os/filesystem.cc
+++ b/src/os/filesystem.cc
@@ -65,26 +65,6 @@ namespace os {
         return edited_a < edited_b;
     }
 
-    std::vector<std::string> list_dir(const std::string& dir) {
-        try {
-            std::vector<std::string> res;
-
-            // Iterates through the directory files and adds them 
-            // to the result
-            std::filesystem::directory_iterator iterator(dir);
-            for(auto& entry : iterator) {
-                res.push_back(entry.path().string());
-            }
-
-            return res;
-        } catch(const std::exception& e) {
-            // When a filesystem exception occurs an empty
-            // string vector is returned
-            return std::vector<std::string>();
-        }
-    }
-
-
     std::string file_dir(const std::string& file) {
         std::string directory;
         

--- a/src/os/filesystem.cc
+++ b/src/os/filesystem.cc
@@ -44,13 +44,6 @@ namespace os {
         return buffer;
     }
 
-    bool compare_file_dates(const std::string& file_a, const std::string& file_b) {
-        auto edited_a = std::filesystem::last_write_time(file_a);
-        auto edited_b = std::filesystem::last_write_time(file_b);
-
-        return edited_a < edited_b;
-    }
-
     std::string file_dir(const std::string& file) {
         std::string directory;
         

--- a/src/os/filesystem.hh
+++ b/src/os/filesystem.hh
@@ -57,15 +57,6 @@ namespace os {
     bool compare_file_dates(const std::string& file_a, const std::string& file_b);
 
     /*
-     * Returns an array of files and folders of a directory
-     * 
-     * @param dir: directory of folder to search
-     * 
-     * @return: Array of files and folders
-     */
-    std::vector<std::string> list_dir(const std::string& dir);
-
-    /*
      * Returns the path to the specified file
      * 
      * @param file: path to the file

--- a/src/os/filesystem.hh
+++ b/src/os/filesystem.hh
@@ -43,13 +43,6 @@ namespace os {
     bool change_dir(const std::string& dir);
 
     /*
-     * Gets the working directory
-     * 
-     * @return: working directory path
-     */
-    std::string get_dir();
-
-    /*
      * Compares the dates of two files
      * 
      * @return: true if file_a is older than file_b, false if not

--- a/src/os/filesystem.hh
+++ b/src/os/filesystem.hh
@@ -22,13 +22,6 @@
 namespace os {
 
     /*
-     * Check if the file exists on the filesystem
-     * 
-     * @param path: path to the file
-     */
-    bool file_exists(const std::string& path);
-
-    /*
      * Reads the file and returns the buffer
      * 
      * @param path: path to the file

--- a/src/os/filesystem.hh
+++ b/src/os/filesystem.hh
@@ -17,7 +17,6 @@
 #pragma once 
 
 #include <memory>
-#include <vector>
 
 namespace os {
 
@@ -27,13 +26,6 @@ namespace os {
      * @param path: path to the file
      */
     std::shared_ptr<char> read_file(const std::string& path);
-
-    /*
-     * Compares the dates of two files
-     * 
-     * @return: true if file_a is older than file_b, false if not
-     */
-    bool compare_file_dates(const std::string& file_a, const std::string& file_b);
 
     /*
      * Returns the path to the specified file

--- a/src/os/filesystem.hh
+++ b/src/os/filesystem.hh
@@ -36,13 +36,6 @@ namespace os {
     std::shared_ptr<char> read_file(const std::string& path);
 
     /*
-     * Changes the directory of the process
-     * 
-     * @param path: path to the directory
-     */
-    bool change_dir(const std::string& dir);
-
-    /*
      * Compares the dates of two files
      * 
      * @return: true if file_a is older than file_b, false if not

--- a/src/os/process_management.cc
+++ b/src/os/process_management.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <cstring>
 #include <sstream>
+#include <filesystem>
 
 #include <stringtoolbox/stringtoolbox.hh>
 #include <spdlog/spdlog.h>
@@ -50,14 +51,14 @@ static std::vector<char*> string_split_null_terminated(const std::string& str, c
 
 bool check_in_path(const std::string& prog) {
     if(prog.find("/") != std::string::npos) {
-        return os::file_exists(prog);
+        return std::filesystem::exists(prog);
     }
 
     std::istringstream stream(getenv("PATH"));
     std::string tmp;
     while(std::getline(stream, tmp, ':')) {
         std::string program_path = tmp + "/" + prog;
-        if(os::file_exists(program_path)) {
+        if(std::filesystem::exists(program_path)) {
             return true;
         }
     }


### PR DESCRIPTION
Functions `os::list_dir`, `os::get_dir`, `os::change_dir`, `os::file_exists` and `os::compare_file_dates` have been replaced with standard library functions. Apart from that,  file reading functions have been changed to use `mmap` instead of the traditional `read` function. And finally, 